### PR TITLE
Remove long lumpy INFO annotations PRPOS and PREND

### DIFF
--- a/svtyper/svtyper.go
+++ b/svtyper/svtyper.go
@@ -121,7 +121,7 @@ func Svtyper(vcf io.Reader, reference string, bam_paths []string, outdir, name s
 		shared.Slogger.Printf("excluding variants with all unknown or homozygous reference genotypes")
 		exRef = " -c 1"
 	}
-	psort = exec.Command("bash", "-c", fmt.Sprintf("set -euo pipefail; gsort /dev/stdin %s.fai | bcftools view -O z%s -o %s && bcftools index --csi %s", reference, exRef, o, o))
+	psort = exec.Command("bash", "-c", fmt.Sprintf("set -euo pipefail; gsort /dev/stdin %s.fai | bcftools annotate -x INFO/PRPOS,INFO/PREND -O z%s -o %s && bcftools index --csi %s", reference, exRef, o, o))
 	psort.Stderr = shared.Slogger
 	var err error
 	si, err = psort.StdinPipe()


### PR DESCRIPTION
Brent;
Thanks for your work on smoove. It's great to have a cleaned up and parallelized approach to running Lumpy and I'm working to incorporate into bcbio to replace our current lumpyexpress based implementation.

This removes the PRPOS and PREND annotations, which are quite big in the final output and don't appear to be directly useful to end users.

If you decide this is worthwhile, would it also be possible to roll a new release with the changed output file naming scheme so I can utilize that from the start in the updated bcbio.

Thanks much for considering this.